### PR TITLE
Use auth state listener for login redirect

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { auth, provider } from '../firebase'
 import {
   signInWithPopup, signInWithRedirect, getRedirectResult,
-  setPersistence, browserLocalPersistence
+  setPersistence, browserLocalPersistence, onAuthStateChanged
 } from 'firebase/auth'
 import { useLocation, useNavigate } from 'react-router-dom'
 
@@ -19,12 +19,14 @@ export default function LoginPage() {
   const [loading, setLoading] = useState(false)
 
   useEffect(() => {
-    getRedirectResult(auth).then(() => {
-      if (auth.currentUser) {
+    const unsub = onAuthStateChanged(auth, user => {
+      if (user) {
         const to = (loc.state?.from?.pathname as string) || '/picks'
         nav(to, { replace: true })
       }
-    }).catch(() => {})
+    })
+    getRedirectResult(auth).catch(() => {})
+    return unsub
   }, [])
 
   const login = async () => {


### PR DESCRIPTION
## Summary
- listen for auth state changes to redirect authenticated users
- clean up login effect and return unsubscribe

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68aa53a74d2c832cae29fd6699fae0f8