### PR TITLE
Gestionar auth con listener y completar interfaz de picks

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,12 +3,22 @@ import { db } from '../firebase'
 import { doc, getDoc } from 'firebase/firestore'
 
 export function useAppConfig() {
-  const [cfg, setCfg] = useState<{ seasonId: string; matchdayNumber: number }>({ seasonId: '2025-26', matchdayNumber: 1 })
+  const [cfg, setCfg] = useState<{ seasonId: string; matchdayNumber: number }>({
+    seasonId: '2025-26',
+    matchdayNumber: 1,
+  })
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
   useEffect(() => {
-    getDoc(doc(db, 'config', 'app')).then(s => {
-      const d = (s.data() as any) || {}
-      setCfg({ seasonId: d.seasonId || '2025-26', matchdayNumber: Number(d.matchdayNumber || 1) })
-    })
+    getDoc(doc(db, 'config', 'app'))
+      .then(s => {
+        const d = (s.data() as any) || {}
+        setCfg({ seasonId: d.seasonId || '2025-26', matchdayNumber: Number(d.matchdayNumber || 1) })
+      })
+      .catch(e => setError(e?.message || 'Error de configuración'))
+      .finally(() => setLoading(false))
   }, [])
-  return cfg
+
+  return { ...cfg, loading, error }
 }

--- a/src/lib/fixtures_2025_26_md1.ts
+++ b/src/lib/fixtures_2025_26_md1.ts
@@ -1,22 +1,22 @@
 
 export const MD1_25_26 = [
   // Viernes 15/08/2025
-  { home: 'gir', away: 'ray', kickoff: '2025-08-15T13:00:00+02:00' },
-  { home: 'vil', away: 'ove', kickoff: '2025-08-15T15:30:00+02:00' },
+  { home: 'GIR', away: 'RAY', kickoff: '2025-08-15T13:00:00+02:00' },
+  { home: 'VIL', away: 'ROV', kickoff: '2025-08-15T15:30:00+02:00' },
 
   // Sábado 16/08/2025
-  { home: 'mal', away: 'fcb', kickoff: '2025-08-16T13:30:00+02:00' },
-  { home: 'ala', away: 'lev', kickoff: '2025-08-16T15:30:00+02:00' },
-  { home: 'val', away: 'rso', kickoff: '2025-08-16T15:30:00+02:00' },
+  { home: 'MAL', away: 'BAR', kickoff: '2025-08-16T13:30:00+02:00' },
+  { home: 'ALA', away: 'LEV', kickoff: '2025-08-16T15:30:00+02:00' },
+  { home: 'VAL', away: 'RSO', kickoff: '2025-08-16T15:30:00+02:00' },
 
   // Domingo 17/08/2025
-  { home: 'cel', away: 'get', kickoff: '2025-08-17T11:00:00+02:00' },
-  { home: 'ath', away: 'sev', kickoff: '2025-08-17T13:30:00+02:00' },
-  { home: 'esp', away: 'atl', kickoff: '2025-08-17T15:30:00+02:00' },
+  { home: 'CEL', away: 'GET', kickoff: '2025-08-17T11:00:00+02:00' },
+  { home: 'ATH', away: 'SEV', kickoff: '2025-08-17T13:30:00+02:00' },
+  { home: 'ESP', away: 'ATM', kickoff: '2025-08-17T15:30:00+02:00' },
 
   // Lunes 18/08/2025
-  { home: 'elc', away: 'bet', kickoff: '2025-08-18T15:00:00+02:00' },
+  { home: 'ELC', away: 'BET', kickoff: '2025-08-18T15:00:00+02:00' },
 
   // Martes 19/08/2025
-  { home: 'rma', away: 'osa', kickoff: '2025-08-19T21:00:00+02:00' },
+  { home: 'RMA', away: 'OSA', kickoff: '2025-08-19T21:00:00+02:00' },
 ]

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react'
 import { auth, provider } from '../firebase'
 import {
-  signInWithPopup, signInWithRedirect, getRedirectResult,
-  setPersistence, browserLocalPersistence
+  signInWithPopup,
+  signInWithRedirect,
+  getRedirectResult,
+  onAuthStateChanged,
 } from 'firebase/auth'
 import { useLocation, useNavigate } from 'react-router-dom'
 
@@ -19,18 +21,19 @@ export default function LoginPage() {
   const [loading, setLoading] = useState(false)
 
   useEffect(() => {
-    getRedirectResult(auth).then(() => {
-      if (auth.currentUser) {
+    const unsub = onAuthStateChanged(auth, user => {
+      if (user) {
         const to = (loc.state?.from?.pathname as string) || '/picks'
         nav(to, { replace: true })
       }
-    }).catch(() => {})
+    })
+    getRedirectResult(auth).catch(() => {})
+    return () => unsub()
   }, [])
 
   const login = async () => {
     setLoading(true)
     try {
-      await setPersistence(auth, browserLocalPersistence)
       if (shouldUseRedirect() || new URLSearchParams(location.search).get('redirect')==='1') {
         await signInWithRedirect(auth, provider); return
       }

--- a/src/pages/PicksPage.tsx
+++ b/src/pages/PicksPage.tsx
@@ -1,41 +1,86 @@
 import { useEffect, useState } from "react";
 import { submitPickFn } from "../lib/functions";
 import { auth } from "../firebase";
+import { onAuthStateChanged } from "firebase/auth";
+import { TEAMS_25_26 } from "../lib/teams";
+import { useAppConfig } from "../lib/config";
+import { MD1_25_26 } from "../lib/fixtures_2025_26_md1";
 
 export default function PicksPage() {
   const [userEmail, setUserEmail] = useState("");
-  const [pickStatus, setPickStatus] = useState("esperando");
+  const [teamId, setTeamId] = useState("");
+  const [sending, setSending] = useState(false);
+  const [message, setMessage] = useState("esperando");
+  const { seasonId, matchdayNumber, loading: cfgLoading, error: cfgError } = useAppConfig();
 
   useEffect(() => {
-    const u = auth.currentUser;
-    if (u && u.email) {
-      setUserEmail(u.email);
-    }
+    const unsub = onAuthStateChanged(auth, (u) => {
+      if (u && u.email) setUserEmail(u.email);
+    });
+    return () => unsub();
   }, []);
 
   const handleSubmitPick = async () => {
+    if (!teamId) {
+      alert("Selecciona un equipo");
+      return;
+    }
+    setSending(true);
+    setMessage("");
     try {
-      const result = await submitPickFn({
-        teamId: "RMA", // ejemplo
-        matchdayId: "2025-26__1"
-      });
-
-      console.log("Respuesta:", result);
-      setPickStatus("enviado");
+      await submitPickFn({ seasonId, matchdayNumber, teamId });
+      setMessage("Pick enviado correctamente");
     } catch (error: any) {
       console.error("Error al enviar pick:", error.message);
-      setPickStatus("error");
+      setMessage("Error al enviar pick");
+    } finally {
+      setSending(false);
     }
   };
 
+  const teamMap = Object.fromEntries(TEAMS_25_26.map(t => [t.id, t]));
+
+  if (cfgLoading) return <p>Cargando configuración...</p>
+  if (cfgError) return <p>Error: {cfgError}</p>
+
   return (
-    <section style={{ padding: "2rem" }}>
-      <h1>ByZapa Porra: Selección de Equipo</h1>
+    <section className="space-y-4">
+      <h1 className="text-2xl font-semibold">Elige tu equipo para Jornada {matchdayNumber}</h1>
       <p>Usuario: {userEmail || "no identificado"}</p>
-      <p>Estado del pick: {pickStatus}</p>
-      <button onClick={handleSubmitPick} className="bg-blue-600 text-white px-4 py-2 rounded mt-4 hover:bg-blue-500">
-        Enviar Pick
+
+      <ul className="space-y-1">
+        {MD1_25_26.map((m, i) => (
+          <li key={i} className={teamId === m.home || teamId === m.away ? "font-semibold" : ""}>
+            {teamMap[m.home]?.short || m.home} vs {teamMap[m.away]?.short || m.away}
+          </li>
+        ))}
+      </ul>
+
+      <div>
+        <label htmlFor="team" className="mr-2">Equipo:</label>
+        <select
+          id="team"
+          value={teamId}
+          onChange={(e) => setTeamId(e.target.value)}
+          className="border rounded px-2 py-1 text-black"
+        >
+          <option value="">-- Selecciona --</option>
+          {TEAMS_25_26.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      {message && <p>{message}</p>}
+      <button
+        onClick={handleSubmitPick}
+        className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-500 disabled:opacity-50"
+        disabled={!teamId || sending}
+      >
+        {sending ? "Enviando..." : "Enviar Pick"}
       </button>
     </section>
   );
 }
+


### PR DESCRIPTION
## Resumen
- Redirige tras login usando `onAuthStateChanged` para evitar bloqueos tras el redirect.
- Expone `loading` y `error` en `useAppConfig` y muestra los partidos de la jornada en PicksPage.
- Unifica los IDs de equipos en los fixtures de la jornada 1.

## Pruebas
- `npm test` *(falla: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa4a4b64fc832c8363b4df86ac0626