### PR TITLE
Normalize team IDs and ensure backend uses uppercase

### DIFF
--- a/src/lib/fixtures_2025_26_md1.ts
+++ b/src/lib/fixtures_2025_26_md1.ts
@@ -1,22 +1,22 @@
 
 export const MD1_25_26 = [
   // Viernes 15/08/2025
-  { home: 'gir', away: 'ray', kickoff: '2025-08-15T13:00:00+02:00' },
-  { home: 'vil', away: 'ove', kickoff: '2025-08-15T15:30:00+02:00' },
+  { home: 'GIR', away: 'RAY', kickoff: '2025-08-15T13:00:00+02:00' },
+  { home: 'VIL', away: 'ROV', kickoff: '2025-08-15T15:30:00+02:00' },
 
   // Sábado 16/08/2025
-  { home: 'mal', away: 'fcb', kickoff: '2025-08-16T13:30:00+02:00' },
-  { home: 'ala', away: 'lev', kickoff: '2025-08-16T15:30:00+02:00' },
-  { home: 'val', away: 'rso', kickoff: '2025-08-16T15:30:00+02:00' },
+  { home: 'MAL', away: 'BAR', kickoff: '2025-08-16T13:30:00+02:00' },
+  { home: 'ALA', away: 'LEV', kickoff: '2025-08-16T15:30:00+02:00' },
+  { home: 'VAL', away: 'RSO', kickoff: '2025-08-16T15:30:00+02:00' },
 
   // Domingo 17/08/2025
-  { home: 'cel', away: 'get', kickoff: '2025-08-17T11:00:00+02:00' },
-  { home: 'ath', away: 'sev', kickoff: '2025-08-17T13:30:00+02:00' },
-  { home: 'esp', away: 'atl', kickoff: '2025-08-17T15:30:00+02:00' },
+  { home: 'CEL', away: 'GET', kickoff: '2025-08-17T11:00:00+02:00' },
+  { home: 'ATH', away: 'SEV', kickoff: '2025-08-17T13:30:00+02:00' },
+  { home: 'ESP', away: 'ATM', kickoff: '2025-08-17T15:30:00+02:00' },
 
   // Lunes 18/08/2025
-  { home: 'elc', away: 'bet', kickoff: '2025-08-18T15:00:00+02:00' },
+  { home: 'ELC', away: 'BET', kickoff: '2025-08-18T15:00:00+02:00' },
 
   // Martes 19/08/2025
-  { home: 'rma', away: 'osa', kickoff: '2025-08-19T21:00:00+02:00' },
+  { home: 'RMA', away: 'OSA', kickoff: '2025-08-19T21:00:00+02:00' },
 ]


### PR DESCRIPTION
## Summary
- Normalize fixture match IDs to match canonical team codes
- Uppercase team IDs when processing picks and seeding data
- Enforce uppercase IDs when ingesting match results

## Testing
- `npm test` (fails: Missing script)
- `npm run build`
- `npm --prefix functions run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa53c66fa8832c8188ab10cf90b8ae